### PR TITLE
Adds minimum TLS version config setting

### DIFF
--- a/kurento.conf.json
+++ b/kurento.conf.json
@@ -1,6 +1,10 @@
 {
   "mediaServer": {
     "crypto" : {
+      "//": "String value for the minimum TLS version to use",
+      "//": "Values: 'tls1.0', 'tls1.1', 'tls1.2'",
+      "//": "If not supplied, Kurento will try and resolve the highest supported version of TLS",
+      "min_tls": "",
       "//": "List of ciphers to use.  If not supplied, then the default set of ciphers from OpenSSL will be used.",
       "//": "Formatted as a colon delimited list.  See https://www.openssl.org/docs/manmaster/man1/ciphers.html0",
       "ciphers": ""

--- a/server/transport/websocket/WebSocketTransport.cpp
+++ b/server/transport/websocket/WebSocketTransport.cpp
@@ -365,7 +365,7 @@ WebSocketTransport::setMinTlsVersion (context_ptr context,
         GST_ERROR ("Error setting minimum TLS version to 1.1");
       }
     #else
-      context->set_options(::SSL_OP_NO_TLSv1);
+      context->set_options(SSL_OP_NO_TLSv1);
     #endif
   } else if ("tls1.2" == min_tls) {
     #if SUPPORTS_SET_MIN_TLS_PROTO
@@ -373,7 +373,7 @@ WebSocketTransport::setMinTlsVersion (context_ptr context,
         GST_ERROR ("Error setting minimum TLS version to 1.2");
       }
     #else
-      context->set_options(::SSL_OP_NO_TLSv1 | ::SSL_OP_NO_TLSv1_1);
+      context->set_options(SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
     #endif
   } else {
     GST_ERROR ("Unsupported minimum TLS version of '%s'.  Ignoring it.", min_tls.c_str());

--- a/server/transport/websocket/WebSocketTransport.cpp
+++ b/server/transport/websocket/WebSocketTransport.cpp
@@ -361,7 +361,7 @@ WebSocketTransport::setMinTlsVersion (context_ptr context,
     // nothing to do here; TLS 1.0 is the lowest supported version.
   } else if ("tls1.1" == min_tls) {
     #if SUPPORTS_SET_MIN_TLS_PROTO
-      if (!::SSL_CTX_set_min_proto_version (context->native_handle(), TLS1_1_VERSION)) {
+      if (!SSL_CTX_set_min_proto_version (context->native_handle(), TLS1_1_VERSION)) {
         GST_ERROR ("Error setting minimum TLS version to 1.1");
       }
     #else
@@ -369,7 +369,7 @@ WebSocketTransport::setMinTlsVersion (context_ptr context,
     #endif
   } else if ("tls1.2" == min_tls) {
     #if SUPPORTS_SET_MIN_TLS_PROTO
-      if (!::SSL_CTX_set_min_proto_version (context->native_handle(), TLS1_2_VERSION)) {
+      if (!SSL_CTX_set_min_proto_version (context->native_handle(), TLS1_2_VERSION)) {
         GST_ERROR ("Error setting minimum TLS version to 1.2");
       }
     #else

--- a/server/transport/websocket/WebSocketTransport.hpp
+++ b/server/transport/websocket/WebSocketTransport.hpp
@@ -29,9 +29,9 @@
 #include <openssl/ssl.h>
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
-  #define SUPPORTS_SET_MIN_TLS_PROTO = 1
+  #define SUPPORTS_SET_MIN_TLS_PROTO 1
 #else
-  #define SUPPORTS_SET_MIN_TLS_PROTO = 0
+  #define SUPPORTS_SET_MIN_TLS_PROTO 0
 #endif
 
 typedef websocketpp::server<websocketpp::config::asio> WebSocketServer;

--- a/server/transport/websocket/WebSocketTransport.hpp
+++ b/server/transport/websocket/WebSocketTransport.hpp
@@ -26,6 +26,13 @@
 #include <iostream>
 #include <thread>
 #include <condition_variable>
+#include <openssl/ssl.h>
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  #define SUPPORTS_SET_MIN_TLS_PROTO = 1
+#else
+  #define SUPPORTS_SET_MIN_TLS_PROTO = 0
+#endif
 
 typedef websocketpp::server<websocketpp::config::asio> WebSocketServer;
 typedef websocketpp::server<websocketpp::config::asio_tls>
@@ -59,6 +66,7 @@ private:
   websocketpp::connection_hdl getConnection (const std::string &sessionId);
 
   static void setCipherList (context_ptr context, const std::string &ciphers);
+  static void setMinTlsVersion (context_ptr context, const std::string &min_tls);
 
   template <typename ServerType>
   void processMessage (ServerType *s, websocketpp::connection_hdl hdl,


### PR DESCRIPTION
This adds the `min_tls` config setting.  This allows us to specify the minimum TLS version we want to support.  If it is not supplied, then Kurento will not set a minimum TLS version and it will simply use the highest supported version between client and server.

The update also checks the version of OpenSSL that is being used to build Kurento with.  If it is built with a OpenSSL 1.1.0 or later, it will use the new `SSL_CTX_set_min_proto_version` function to set the minimum TLS version.  Older versions of OpenSSL have to manually set the various `SSL_OP_NO_TLS*` flags to turn off TLS versions lower than the specified minimum.