### PR TITLE
Add OpenSSL FIPS mode config setting

### DIFF
--- a/kurento.conf.json
+++ b/kurento.conf.json
@@ -1,6 +1,9 @@
 {
   "mediaServer": {
     "crypto" : {
+      "//": "Whether or not to use OpenSSL's FIPS mode",
+      "//": "Default: false",
+      "fips": false,
       "//": "String value for the minimum TLS version to use",
       "//": "Values: 'tls1.0', 'tls1.1', 'tls1.2'",
       "//": "If not supplied, Kurento will try and resolve the highest supported version of TLS",

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -67,21 +67,21 @@ toggleFIPSMode (boost::property_tree::ptree &config)
   const bool fipsEnabled = (FIPS_mode() != 0);
 
   if (useFips && fipsEnabled) {
-    GST_DEBUG ("FIPS mode already enabled");
+    GST_INFO ("FIPS mode already enabled");
     return;
   } else if (!useFips && !fipsEnabled) {
     // In most cases, users don't need to supply the 'fips' config setting, so
     // no need to spam the log them if it's not enabled and we don't want it enabled.
     return;
   } else if (useFips) {
-    GST_DEBUG ("Enabling FIPS mode");
+    GST_INFO ("Enabling FIPS mode");
     if (!FIPS_mode_set(1 /*on*/))
     {
       GST_ERROR ("Error enabling FIPS mode: %s", ERR_error_string(ERR_get_error(), NULL));
       exit (1);
     }
   } else {
-    GST_DEBUG ("Disabling FIPS mode");
+    GST_INFO ("Disabling FIPS mode");
     if (!FIPS_mode_set(0 /*off*/))
     {
       GST_ERROR ("Error disabling FIPS mode: %s", ERR_error_string(ERR_get_error(), NULL));

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -61,7 +61,7 @@ namespace logging = boost::log;
 Glib::RefPtr<Glib::MainLoop> loop = Glib::MainLoop::create ();
 
 static void
-checkFIPSMode (boost::property_tree::ptree &config)
+toggleFIPSMode (boost::property_tree::ptree &config)
 {
   const bool useFips = config.get<bool> ("mediaServer.crypto.fips", false);
   const bool fipsEnabled = (FIPS_mode() != 0);
@@ -283,6 +283,8 @@ main (int argc, char **argv)
 
     killServerOnLowResources (*killResourceLimit);
   }
+
+  toggleFIPSMode (config);
 
   transport = createTransportFromConfig (config);
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -38,6 +38,7 @@
 #include <boost/optional.hpp>
 
 #include <openssl/crypto.h>
+#include <openssl/err.h>
 
 #include "logging.hpp"
 #include "modules.hpp"

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -37,6 +37,8 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/optional.hpp>
 
+#include <openssl/crypto.h>
+
 #include "logging.hpp"
 #include "modules.hpp"
 #include "loadConfig.hpp"
@@ -56,6 +58,36 @@ using namespace ::kurento;
 namespace logging = boost::log;
 
 Glib::RefPtr<Glib::MainLoop> loop = Glib::MainLoop::create ();
+
+static void
+checkFIPSMode (boost::property_tree::ptree &config)
+{
+  const bool useFips = config.get<bool> ("mediaServer.crypto.fips", false);
+  const bool fipsEnabled = (FIPS_mode() != 0);
+
+  if (useFips && fipsEnabled) {
+    GST_DEBUG ("FIPS mode already enabled");
+    return;
+  } else if (!useFips && !fipsEnabled) {
+    // In most cases, users don't need to supply the 'fips' config setting, so
+    // no need to spam the log them if it's not enabled and we don't want it enabled.
+    return;
+  } else if (useFips) {
+    GST_DEBUG ("Enabling FIPS mode");
+    if (!FIPS_mode_set(1 /*on*/))
+    {
+      GST_ERROR ("Error enabling FIPS mode: %s", ERR_error_string(ERR_get_error(), NULL));
+      exit (1);
+    }
+  } else {
+    GST_DEBUG ("Disabling FIPS mode");
+    if (!FIPS_mode_set(0 /*off*/))
+    {
+      GST_ERROR ("Error disabling FIPS mode: %s", ERR_error_string(ERR_get_error(), NULL));
+      exit (1);
+    }
+  }
+}
 
 static std::shared_ptr<Transport>
 createTransportFromConfig (boost::property_tree::ptree &config)


### PR DESCRIPTION
Adds a new config setting to toggle OpenSSL FIPS mode on/off.  The OpenSSL FIPS mode is used when we need to comply with the Federal Information Processing Standards (FIPS) listed here: https://www.nist.gov/standardsgov/compliance-faqs-federal-information-processing-standards-fips

This update will attempt to enable / disable FIPS mode based on the new config setting.  If it fails to set the FIPS mode, it will immediately exit out with an error since we assume that changing the FIPS mode is important enough that failure should stop the server.